### PR TITLE
Fix room size on game start logic

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/web/src/contexts/GameStateContext/GameStateContext.tsx
+++ b/web/src/contexts/GameStateContext/GameStateContext.tsx
@@ -1,17 +1,13 @@
-import { createContext, FC, useContext, useEffect, useRef } from "react";
+import { createContext, FC, useContext, useEffect, useMemo, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { SocketIncoming, SocketMessage as OutboundSocketMessage } from "../../../../server/types/socket.types";
-import { PlayerId, Player, GameData, Card } from "../../../../server/types/types";
+import { Card } from "../../../../server/types/types";
 import { SocketMessage } from "./GameStateContext.types";
-import { useGameStateReducer } from "./useGameStateReducer";
+import { RoomGameState, useGameStateReducer } from "./useGameStateReducer";
 
-interface GameStateContextValue {
-  players: Map<PlayerId, Player>;
+interface GameStateContextValue extends Omit<RoomGameState, "discard"> {
   discard: Array<Card | "Hidden">;
-  currentPlayerId: PlayerId;
   sendGameUpdate: (msg: OutboundSocketMessage) => void;
-  deckCount: number;
-  gameState: GameData | null;
 }
 
 const GameStateContext = createContext<GameStateContextValue | null>(null);
@@ -20,14 +16,9 @@ export const GameStateProvider: FC = ({ children }) => {
   const navigate = useNavigate();
   const { roomCode = "" } = useParams();
   const [roomGameState, dispatch] = useGameStateReducer();
-  const roomSizeRef = useRef<number>(1);
   const webscoketRef = useRef<WebSocket | null>(null);
 
   const sendGameUpdate = (msg: OutboundSocketMessage) => {
-    if (msg.type === SocketIncoming.StartGame) {
-      roomSizeRef.current = roomGameState.players.size;
-    }
-
     webscoketRef.current?.send(JSON.stringify(msg));
   };
 
@@ -66,24 +57,30 @@ export const GameStateProvider: FC = ({ children }) => {
    * 2 players removes 3 cards; > 2 players removes 1 so replace the auto removed cards
    * with "Hidden".
    */
-  const discardWithHidden: Array<Card | "Hidden"> = roomGameState.discard
-    .map((card, index) => {
-      if (roomGameState.gameState?.started && roomSizeRef.current < 2) {
-        throw new Error("Game started with less than 2 players which should be impossible.");
-      }
+  const discardWithHidden: Array<Card | "Hidden"> = useMemo(() => {
+    const roomSize = roomGameState.players.size;
 
-      if ((roomSizeRef.current === 2 && index < 3) || (roomSizeRef.current > 2 && index === 0)) {
-        return "Hidden";
-      } else {
-        return card;
-      }
-    })
-    /**
-     * Discard pile is reversed when sent from the backend so the most recent discard
-     * is on the bottom (last index). Reverse the order so that the top card is the most
-     * recently played. Makes it easier when displaying the discard pile
-     */
-    .reverse();
+    if (roomGameState.gameState?.started && roomSize < 2) {
+      throw new Error("Game started with less than 2 players which should be impossible.");
+    }
+
+    return (
+      roomGameState.discard
+        .map((card, index) => {
+          if ((roomSize === 2 && index < 3) || (roomSize > 2 && index === 0)) {
+            return "Hidden";
+          } else {
+            return card;
+          }
+        })
+        /**
+         * Discard pile is reversed when sent from the backend so the most recent discard
+         * is on the bottom (last index). Reverse the order so that the top card is the most
+         * recently played. Makes it easier when displaying the discard pile
+         */
+        .reverse()
+    );
+  }, [Boolean(roomGameState.gameState?.started)]);
 
   return (
     <GameStateContext.Provider value={{ ...roomGameState, discard: discardWithHidden, sendGameUpdate }}>

--- a/web/src/contexts/GameStateContext/useGameStateReducer.ts
+++ b/web/src/contexts/GameStateContext/useGameStateReducer.ts
@@ -3,7 +3,7 @@ import { SocketOutgoing } from "../../../../server/types/socket.types";
 import { PlayerId, Player, Card, GameData } from "../../../../server/types/types";
 import { SocketMessage } from "./GameStateContext.types";
 
-interface RoomGameState {
+export interface RoomGameState {
   currentPlayerId: PlayerId;
   players: Map<PlayerId, Player>;
   deckCount: number;


### PR DESCRIPTION
Closes #16 

This work fixes the room size on game start logic by memoizing the discard pile until the game starts/ends.

Also included are some small type updates and removed the favicon reference that doesn't exist.